### PR TITLE
Adding utf-8 check

### DIFF
--- a/csh_ldap/group.py
+++ b/csh_ldap/group.py
@@ -35,10 +35,20 @@ class CSHGroup:
                 "(memberof=%s)" % self.__dn__,
                 ['uid'])
 
+        ret = []
+        for val in res:
+            val = val[1]['uid'][0]
+            try:
+                ret.append(val.decode('utf-8'))
+            except UnicodeDecodeError:
+                ret.append(val)
+            except KeyError:
+                continue
+
         return [CSHMember(self.__lib__,
-                result[1]['uid'][0],
+                result,
                 uid=True)
-                for result in res]
+                for result in ret]
 
     def check_member(self, member, dn=False):
         """Check if a Member is in the bound group.

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ summary = CSH LDAP ORM
 url = https://github.com/liam-middlebrook/csh_ldap
 description-file = README.md
 license = MIT
-version = 2.0.1
+version = 2.0.2
 classifier =
     Natural Language :: English
     Operating System :: POSIX :: Linux


### PR DESCRIPTION
Was running into an issue where getting a group fails in python 3.6, but works in 2.7. @mbillow recommended adding back this check. I'm not entirely sure if this fixes it, or works as I'm not familiar with the application.
Feel free to make fixes to the PR if they're needed.