### PR TITLE
Add searching for members by slack UID

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ liam = instance.get_member(uid_of_liam, uid=True)
 # Get member by iButton ID
 liam = instance.get_member_ibutton(ibutton_id)
 
+# Get member by Slack UID
+liam = instance.get_member_slackuid(slack_uid)
+
 # Get group by cn
 rtp = instance.get_group('rtp')
 

--- a/csh_ldap/__init__.py
+++ b/csh_ldap/__init__.py
@@ -71,6 +71,27 @@ class CSHLDAP:
                     False)
         return None
 
+    def get_member_slackuid(self, slack):
+        """Get a CSHMember object.
+
+        Arguments:
+        slack -- the Slack UID of the member
+
+        Returns:
+        None if the Slack UID provided does not correspond to a CSH Member
+        """
+        members = self.__con__.search_s(
+            CSHMember.__ldap_user_ou__,
+            ldap.SCOPE_SUBTREE,
+            "(slackuid=%s)" % slack,
+            ['ipaUniqueID'])
+        if members:
+            return CSHMember(
+                    self,
+                    members[0][1]['ipaUniqueID'][0].decode('utf-8'),
+                    False)
+        return None
+
     def get_group(self, val):
         """Get a CSHGroup object.
 


### PR DESCRIPTION
Facilitates identifying users via SlackUID by providing a search
functionality, making slack bot integration simpler and less hacky.