### PR TITLE
Comparison fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 install:
   - "pip install -r requirements.txt"

--- a/csh_ldap/member.py
+++ b/csh_ldap/member.py
@@ -36,6 +36,21 @@ class CSHMember:
         else:
             raise KeyError("Invalid Search Name")
 
+    def __eq__(self, other):
+        if isinstance(other, CSHMember):
+            return self.__dn__ == other.__dn__
+        return False
+
+    def __hash__(self):
+        """Generate a unique hash value for the bound CSH LDAP member object.
+        """
+        return hash(self.__dn__)
+
+    def __repr__(self):
+        """Generate a str representation of the bound CSH LDAP member object.
+        """
+        return "CSH Member(dn: %s)" % self.__dn__
+
     def get(self, key):
         """Get an attribute from the bound CSH LDAP member object.
 
@@ -90,13 +105,12 @@ class CSHMember:
                     continue
 
             return ret
-        else:
-            try:
-                return res[0][1][key][0].decode('utf-8')
-            except UnicodeDecodeError:
-                return res[0][1][key][0]
-            except KeyError:
-                return None
+        try:
+            return res[0][1][key][0].decode('utf-8')
+        except UnicodeDecodeError:
+            return res[0][1][key][0]
+        except KeyError:
+            return None
 
     def __setattr__(self, key, value):
         ldap_mod = None

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,2 @@
 pycodestyle==2.4.0
-pylint==1.8.4
+pylint==2.5.2


### PR DESCRIPTION
### What?
Adds `__hash__()`, `__eq__()`, and `__repr__()` to CSHMember objects.

### Why?
Without `__eq__()` things like [list or set differencing](https://github.com/ComputerScienceHouse/conditional/blob/e3dab17eb4495e2177852a4988e20405ee04220c/conditional/util/member.py#L36) don't work, and `__hash__()` goes along with `__eq__()`.

Also adds `__repr__()` because I find dn to be more helpful than the memory address of a CSHMember instance, along the lines of #22.

### Caveats
I'm running python 3.8
* Python 3.7 and 3.8 added to travis.yml
* Pylint bumped to 2.5.2
  * Bump includes fixes that allow pylint to run in python 3.8
  * Python 3.4 is EOL and not supported by newer versions of pylint, thus has been dropped from travis tests.