### PR TITLE
Modify method for connecting to ldap servers

### DIFF
--- a/csh_ldap/__init__.py
+++ b/csh_ldap/__init__.py
@@ -35,8 +35,7 @@ def reconnect_on_fail(method):
             try:
                 result = method(*method_args, **method_kwargs)
                 return result
-            #   pylint: disable=broad-except
-            except Exception:
+            except (ldap.SERVER_DOWN, ldap.TIMEOUT):
                 ldap_srvs = srvlookup.lookup(
                     "ldap", "tcp", ldap_obj.__domain__)
                 ldap_obj.ldap_uris = ['ldaps://' + uri.hostname


### PR DESCRIPTION
This is necessary to retrieve the specific server to which ldap is connected, which is required in order to implement healthchecks (i.e. what is described here in [this issue](https://github.com/ComputerScienceHouse/profiles/issues/77).