### PR TITLE
Circular import hotfix

### DIFF
--- a/csh_ldap/__init__.py
+++ b/csh_ldap/__init__.py
@@ -1,59 +1,10 @@
-from functools import wraps
 from enum import Enum
 import ldap
 from ldap.ldapobject import ReconnectLDAPObject
 import srvlookup
 from csh_ldap.member import CSHMember
 from csh_ldap.group import CSHGroup
-
-MAX_RECONNECTS = 3
-
-
-def reconnect_on_fail(method):
-    """
-    Decorator for CSHLDAP operations that attempts to reconnect and recall a
-    method on a failed call.
-
-    :param method: Method to call
-    :return: wrapper function
-    """
-
-    @wraps(method)
-    def wrapper(*method_args, **method_kwargs):
-        """
-        Wrapper for method, calls method and returns the result if successful,
-         otherwise tries reconnecting.
-
-        :param method_args: method's arguments
-        :param method_kwargs: method's keyword arguments
-        :return: result of method call
-        """
-        max_reconnects = MAX_RECONNECTS
-        ldap_obj = method_args[0] if isinstance(method_args[0], CSHLDAP) else\
-            method_args[0].__lib__
-        while max_reconnects:
-            try:
-                result = method(*method_args, **method_kwargs)
-                return result
-            except (ldap.SERVER_DOWN, ldap.TIMEOUT):
-                ldap_srvs = srvlookup.lookup(
-                    "ldap", "tcp", ldap_obj.__domain__)
-                ldap_obj.ldap_uris = ['ldaps://' + uri.hostname
-                                      for uri in ldap_srvs]
-
-                for uri in ldap_obj.ldap_uris:
-                    try:
-                        ldap_obj.__con__.reconnect(uri)
-                        ldap_obj.server_uri = uri
-                        result = method(*method_args, **method_kwargs)
-                        return result
-                    except (ldap.SERVER_DOWN, ldap.TIMEOUT):
-                        continue
-                max_reconnects -= 1
-                if max_reconnects == 0:
-                    raise
-
-    return wrapper
+from csh_ldap.utility import reconnect_on_fail
 
 
 class CSHLDAP:

--- a/csh_ldap/group.py
+++ b/csh_ldap/group.py
@@ -1,6 +1,6 @@
 import ldap
 from csh_ldap.member import CSHMember
-from . import reconnect_on_fail
+from csh_ldap.utility import reconnect_on_fail
 
 
 class CSHGroup:

--- a/csh_ldap/member.py
+++ b/csh_ldap/member.py
@@ -1,5 +1,5 @@
 import ldap
-from . import reconnect_on_fail
+from csh_ldap.utility import reconnect_on_fail
 
 
 class CSHMember:

--- a/csh_ldap/utility.py
+++ b/csh_ldap/utility.py
@@ -1,0 +1,52 @@
+from functools import wraps
+import ldap
+import srvlookup
+
+MAX_RECONNECTS = 3
+
+
+def reconnect_on_fail(method):
+    """
+    Decorator for CSHLDAP operations that attempts to reconnect and recall a
+    method on a failed call.
+
+    :param method: Method to call
+    :return: wrapper function
+    """
+
+    @wraps(method)
+    def wrapper(*method_args, **method_kwargs):
+        """
+        Wrapper for method, calls method and returns the result if successful,
+         otherwise tries reconnecting.
+
+        :param method_args: method's arguments
+        :param method_kwargs: method's keyword arguments
+        :return: result of method call
+        """
+        max_reconnects = MAX_RECONNECTS
+        ldap_obj = method_args[0] if "CSHLDAP" in [t.__name__ for t in type(
+                method_args[0]).__mro__] else method_args[0].__lib__
+        while max_reconnects:
+            try:
+                result = method(*method_args, **method_kwargs)
+                return result
+            except (ldap.SERVER_DOWN, ldap.TIMEOUT):
+                ldap_srvs = srvlookup.lookup(
+                    "ldap", "tcp", ldap_obj.__domain__)
+                ldap_obj.ldap_uris = ['ldaps://' + uri.hostname
+                                      for uri in ldap_srvs]
+
+                for uri in ldap_obj.ldap_uris:
+                    try:
+                        ldap_obj.__con__.reconnect(uri)
+                        ldap_obj.server_uri = uri
+                        result = method(*method_args, **method_kwargs)
+                        return result
+                    except (ldap.SERVER_DOWN, ldap.TIMEOUT):
+                        continue
+                max_reconnects -= 1
+                if max_reconnects == 0:
+                    raise
+
+    return wrapper

--- a/csh_ldap/utility.py
+++ b/csh_ldap/utility.py
@@ -25,8 +25,15 @@ def reconnect_on_fail(method):
         :return: result of method call
         """
         max_reconnects = MAX_RECONNECTS
-        ldap_obj = method_args[0] if "CSHLDAP" in [t.__name__ for t in type(
-                method_args[0]).__mro__] else method_args[0].__lib__
+        is_cshldap = lambda arg: any(
+                filter(
+                    lambda t: t.__name__ == 'CSHLDAP',
+                    type(arg).__mro__
+                    )
+                )
+        ldap_obj = next(filter(is_cshldap, method_args)) \
+                   if any(filter(is_cshldap, method_args)) \
+                   else method_args[0].__lib__
         while max_reconnects:
             try:
                 result = method(*method_args, **method_kwargs)


### PR DESCRIPTION
Attempt to fix circular imports by moving reconnect_on_fail to a new
file utility.py. Can't test code on my own at all so failure is possible.